### PR TITLE
Refactor/28 비동기 처리를 통한 장학금 추천 api 성능 개선

### DIFF
--- a/src/main/java/com/grantip/backend/domain/scholarship/controller/ScholarshipController.java
+++ b/src/main/java/com/grantip/backend/domain/scholarship/controller/ScholarshipController.java
@@ -1,5 +1,6 @@
 package com.grantip.backend.domain.scholarship.controller;
 
+import com.grantip.backend.domain.scholarship.domain.dto.RecommendationResult;
 import com.grantip.backend.domain.scholarship.domain.dto.request.RecommendedScholarshipRequest;
 import com.grantip.backend.domain.scholarship.domain.dto.request.ScholarshipSearchRequest;
 import com.grantip.backend.domain.scholarship.domain.dto.response.RecommendedScholarshipResponse;
@@ -63,13 +64,35 @@ public class ScholarshipController implements ScholarshipControllerDocs {
   @GetMapping("/recommendation")
   public ResponseEntity<ApiResponse<Page<RecommendedScholarshipResponse>>> recommend(
       @AuthenticationPrincipal UserDetails userDetails,
-      @ParameterObject @Valid RecommendedScholarshipRequest request){
-    return ResponseEntity.ok(
-        ApiResponse.<Page<RecommendedScholarshipResponse>>builder()
-            .success(true)
-            .code(200)
-            .result(scholarshipService.recommend(userDetails.getUsername(), request.toPageable()))
-            .message("추천 장학금 조회에 성공했습니다.")
-            .build());
+      @ParameterObject @Valid RecommendedScholarshipRequest request) {
+
+    RecommendationResult result = scholarshipService.recommend(
+        userDetails.getUsername(),
+        request.toPageable()
+    );
+
+    return switch (result.status()) {
+      case COMPLETED -> ResponseEntity.ok(
+          ApiResponse.<Page<RecommendedScholarshipResponse>>builder()
+              .success(true)
+              .code(200)
+              .result(result.data())
+              .message("추천 장학금 조회에 성공했습니다.")
+              .build());
+      case PENDING -> ResponseEntity.accepted().body(
+          ApiResponse.<Page<RecommendedScholarshipResponse>>builder()
+              .success(true)
+              .code(202)
+              .result(null)
+              .message("추천 정보를 준비하고 있습니다. 잠시 후 다시 시도해주세요.")
+              .build());
+      case EMPTY -> ResponseEntity.ok(
+          ApiResponse.<Page<RecommendedScholarshipResponse>>builder()
+              .success(true)
+              .code(200)
+              .result(result.data())
+              .message("추천할 수 있는 장학금이 없습니다.")
+              .build());
+    };
   }
 }

--- a/src/main/java/com/grantip/backend/domain/scholarship/controller/ScholarshipControllerDocs.java
+++ b/src/main/java/com/grantip/backend/domain/scholarship/controller/ScholarshipControllerDocs.java
@@ -7,6 +7,7 @@ import com.grantip.backend.domain.scholarship.domain.dto.response.ScholarshipDet
 import com.grantip.backend.domain.scholarship.domain.dto.response.ScholarshipSummaryResponse;
 import com.grantip.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -92,31 +93,85 @@ public interface ScholarshipControllerDocs {
   );
 
   @Operation(
-      summary = "추천 장학금 조회",
+      summary = "개인별 맞춤 장학금 추천 조회",
       description = """
-            ### 요청 파라미터
-            - `pageNumber` (Integer, optional, default=1): 페이지 번호
-            - `pageSize` (Integer, optional, default=10): 페이지 크기
+        개인화된 추천 장학금 목록을 비동기적으로 조회합니다.
+        
+        ### 기능 요약
+        - 사용자의 정보를 바탕으로 추천 점수가 계산된 장학금 목록을 제공합니다.
+        - **사용자가 로그인할 때 추천 캐시가 없는 경우, 백그라운드에서 비동기적으로 추천 계산을 시작합니다.**
+        - 이 API는 계산이 진행 중이거나 완료된 추천 결과를 조회하는 데 사용됩니다. 클라이언트는 서버의 응답 상태에 따라 데이터를 즉시 받거나, 잠시 후 다시 요청(폴링)해야 할 수 있습니다.
 
-            ### 응답 데이터
-            - `result.content` (List of RecommendedScholarshipResponse):
-              - 기본 상세 필드 동일 (ScholarshipDetailResponse)
-              - `score` (double): 추천 점수
-            - 페이징 메타데이터 (totalElements, totalPages, number, size)
+        ### 요청 흐름
+        1. **최초 요청:** 로그인 후, 클라이언트는 `GET /api/scholarships/recommendation`을 호출합니다.
+        2. **서버 응답 분기:**
+           - **(A) 데이터 즉시 반환 (`200 OK`):** 캐시에 이미 추천 결과가 있는 경우, 즉시 데이터와 함께 응답합니다.
+           - **(B) 처리 시작 또는 진행 중 알림 (`202 Accepted`):** 캐시에 결과가 없어 **로그인 시 시작된 계산이 아직 진행 중**인 경우, `result`가 `null`인 응답과 함께 "처리 중"임을 알립니다. 서버에서는 **Redis Lock을 통해 중복 계산을 방지**하므로, 여러 번 호출해도 계산은 한 번만 실행됩니다.
+        3. **클라이언트 후속 조치:**
+           - **(A)의 경우:** 받은 데이터를 화면에 표시합니다.
+           - **(B)의 경우:** 로딩 UI를 표시하고, **1~2초 간격 (권장: 1.5초)으로** 동일한 API를 다시 호출(폴링)하여 데이터가 준비되었는지 확인합니다. 최초 계산에 **통상 3~4초가 소요**되므로, 2~3회 폴링 내에 `200 OK` 응답을 기대할 수 있습니다.
 
-            ### 사용 방법
-            1. HTTP `GET /api/scholarships/recommendation` 요청을 보냅니다.
-            2. Header에 `Authorization: Bearer {token}`을 포함해야 합니다.
-
-            ### 유의 사항
-            - 인증된 사용자만 호출할 수 있습니다.
-
-            ### 예외 처리
-            - `UNAUTHORIZED` (401): 인증되지 않은 사용자입니다.
-            - `USER_NOT_FOUND` (404): 사용자를 찾을 수 없습니다.
-            - `BAD_REQUEST` (400): 파라미터 유효성 오류 시 반환됩니다.
-            - `INTERNAL_SERVER_ERROR` (500): 서버 내부 오류 발생 시 반환됩니다.
-            """
+        ### 요청 파라미터
+        - `page` (Integer, optional, default=0): 페이지 번호 (0부터 시작)
+        - `size` (Integer, optional, default=10): 페이지 크기
+        
+        ### 응답 데이터
+        - **상태 200 (OK)**
+        ```json
+        {
+          "success": true,
+          "code": 200,
+          "result": {
+            "content": [
+              {
+                // RecommendedScholarshipResponse의 기본 필드 (장학금 ID, 명칭 등)
+                // + `score` (double): 추천 점수
+              }
+            ],
+            "pageable": {
+              "pageNumber": 0,
+              "pageSize": 10
+            },
+            "totalElements": 15,
+            "totalPages": 2,
+            "number": 0,
+            "size": 10
+          },
+          "message": "추천 장학금 조회에 성공했습니다."
+        }
+        ```
+        - **상태 202 (Accepted)**
+        ```json
+        {
+          "success": true,
+          "code": 202,
+          "result": null,
+          "message": "추천 정보를 준비하고 있습니다. 잠시 후 다시 시도해주세요."
+         }
+        ```
+        - **상태 200 (OK, 빈 결과)**
+        ```json
+        {
+          "success": true,
+          "code": 200,
+          "result": {
+            "content": [],
+            "pageable": { "pageNumber": 0, "pageSize": 10 },
+            "totalElements": 0,
+            "totalPages": 0,
+            "number": 0,
+            "size": 10
+          },
+          "message": "추천할 수 있는 장학금이 없습니다."
+        }
+        ```
+        
+        ### 예외 처리
+        - `401 UNAUTHORIZED`: 인증 정보가 없거나 토큰이 유효하지 않습니다.
+        - `404 USER_NOT_FOUND`: 해당 이메일의 사용자를 찾을 수 없습니다.
+        - `400 BAD_REQUEST`: `page` 또는 `size` 파라미터 유효성 검사 실패 시 발생합니다.
+        - `500 INTERNAL_SERVER_ERROR`: 서버 내부 오류 발생 시 반환됩니다.
+        """
   )
   ResponseEntity<ApiResponse<Page<RecommendedScholarshipResponse>>> recommend(
       UserDetails userDetails,

--- a/src/main/java/com/grantip/backend/domain/scholarship/domain/constant/RecommendationStatus.java
+++ b/src/main/java/com/grantip/backend/domain/scholarship/domain/constant/RecommendationStatus.java
@@ -1,0 +1,7 @@
+package com.grantip.backend.domain.scholarship.domain.constant;
+
+public enum RecommendationStatus {
+  COMPLETED, // 데이터 있음
+  PENDING, // 처리 중
+  EMPTY // 결과가 비어 있음
+}

--- a/src/main/java/com/grantip/backend/domain/scholarship/domain/dto/RecommendationResult.java
+++ b/src/main/java/com/grantip/backend/domain/scholarship/domain/dto/RecommendationResult.java
@@ -1,0 +1,9 @@
+package com.grantip.backend.domain.scholarship.domain.dto;
+
+import com.grantip.backend.domain.scholarship.domain.constant.RecommendationStatus;
+import com.grantip.backend.domain.scholarship.domain.dto.response.RecommendedScholarshipResponse;
+import org.springframework.data.domain.Page;
+
+
+public record RecommendationResult(RecommendationStatus status, Page<RecommendedScholarshipResponse> data) {
+}

--- a/src/main/java/com/grantip/backend/domain/scholarship/service/RecommendationAsyncService.java
+++ b/src/main/java/com/grantip/backend/domain/scholarship/service/RecommendationAsyncService.java
@@ -1,0 +1,16 @@
+package com.grantip.backend.domain.scholarship.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationAsyncService {
+  private final ScholarshipRecommendationService recommendationService;
+
+  @Async
+  public void triggerRecommendationCalculation(String identifier){
+    recommendationService.calculateRecommendations(identifier);
+  }
+}

--- a/src/main/java/com/grantip/backend/domain/scholarship/service/ScholarshipService.java
+++ b/src/main/java/com/grantip/backend/domain/scholarship/service/ScholarshipService.java
@@ -1,5 +1,9 @@
 package com.grantip.backend.domain.scholarship.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grantip.backend.domain.scholarship.domain.constant.RecommendationStatus;
+import com.grantip.backend.domain.scholarship.domain.dto.RecommendationResult;
 import com.grantip.backend.domain.scholarship.domain.dto.request.ScholarshipSearchRequest;
 import com.grantip.backend.domain.scholarship.domain.dto.response.RecommendedScholarshipResponse;
 import com.grantip.backend.domain.scholarship.domain.dto.response.ScholarshipDetailResponse;
@@ -10,11 +14,13 @@ import com.grantip.backend.domain.scholarship.repository.ScholarshipRepository;
 import com.grantip.backend.domain.scholarship.repository.ScholarshipRepositoryCustom;
 import com.grantip.backend.global.code.ErrorCode;
 import com.grantip.backend.global.exception.CustomException;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +30,9 @@ public class ScholarshipService {
   private final ScholarshipRepository scholarshipRepository;
   private final ScholarshipMapper scholarshipMapper;
   private final ScholarshipRepositoryCustom scholarshipRepositoryCustom;
-  private final ScholarshipRecommendationService recommendationService;
+  private final RecommendationAsyncService asyncService;
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final ObjectMapper objectMapper;
 
   /**
    * 장학금 Id로 조회
@@ -56,15 +64,44 @@ public class ScholarshipService {
    * 사용자별 추천 장학금 조회 메서드
    */
   @Transactional(readOnly = true)
-  public Page<RecommendedScholarshipResponse> recommend(String identifier, Pageable pageable){
-    // 전체 추천 목록 조회 (Cache Hit이면 Redis에서, Cache Miss이면 계산 후 Redis에 저장하고 결과를 가져옴)
-    List<RecommendedScholarshipResponse> fullList = recommendationService.calculateRecommendations(identifier);
+  public RecommendationResult recommend(String identifier, Pageable pageable){
+    String cacheKey = "recommendations::" + identifier;
+    String lockKey = "recommendations:lock:" + identifier;
 
-    // 페이징 처리
+    // 캐시 Hit
+    if(redisTemplate.hasKey(cacheKey)){
+      Object cachedObject = redisTemplate.opsForValue().get(cacheKey);
+
+      List<RecommendedScholarshipResponse> fullList = objectMapper.convertValue(
+          cachedObject,
+          new TypeReference<>() {
+          }
+      );
+      Page<RecommendedScholarshipResponse> pagedData = createPage(fullList, pageable);
+
+      return new RecommendationResult(
+          pagedData.isEmpty() ? RecommendationStatus.EMPTY : RecommendationStatus.COMPLETED,
+          pagedData
+          );
+    }
+
+    // 캐시 Miss & Lock (계산 중)
+    if(redisTemplate.hasKey(lockKey)){
+      return new RecommendationResult(RecommendationStatus.PENDING, null);
+    }
+
+    // 캐시 Miss & No Lock -> 비동기 계산 트리거
+    redisTemplate.opsForValue().set(lockKey, "locked", Duration.ofSeconds(30));
+    asyncService.triggerRecommendationCalculation(identifier);
+
+    return new RecommendationResult(RecommendationStatus.PENDING, null);
+  }
+
+  // List를 Page로 변환하는 헬퍼 메서드
+  private Page<RecommendedScholarshipResponse> createPage(List<RecommendedScholarshipResponse> fullList, Pageable pageable) {
     int start = (int) pageable.getOffset();
     int end = Math.min((start + pageable.getPageSize()), fullList.size());
     List<RecommendedScholarshipResponse> pagedList = (start >= fullList.size()) ? List.of() : fullList.subList(start, end);
-
     return new PageImpl<>(pagedList, pageable, fullList.size());
   }
 }

--- a/src/main/java/com/grantip/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/grantip/backend/domain/user/controller/AuthController.java
@@ -110,7 +110,7 @@ public class AuthController implements AuthControllerDocs {
                                                     HttpServletRequest request){
         // 쿠키확인해서 refresh 기간 지났는지, 있는지 확인해서 예외처리 가능
         String accessToken = (String) request.getAttribute("accessToken");
-        authService.logout(userDetails.getEmail(), accessToken);
+        authService.logout(userDetails.getUsername(), accessToken);
 
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", null)
                 .httpOnly(true)

--- a/src/main/java/com/grantip/backend/domain/user/controller/AuthControllerDocs.java
+++ b/src/main/java/com/grantip/backend/domain/user/controller/AuthControllerDocs.java
@@ -52,27 +52,33 @@ public interface AuthControllerDocs {
   @Operation(
       summary = "로그인",
       description = """
-            ### 요청 파라미터
-            - `email` (String, required): 이메일
-            - `password` (String, required): 비밀번호
+          ### 기능 요약
+          - 사용자 인증을 처리하고, 접근 토큰(Access Token)과 갱신 토큰(Refresh Token)을 발급합니다.
+          - **또한, 로그인 성공 시 사용자의 추천 캐시가 없는 경우, 백그라운드에서 개인별 맞춤 장학금 추천 목록 계산을 비동기적으로 시작합니다.**
+          - 이 비동기 작업은 로그인 응답 시간에 영향을 주지 않으며, 이후 추천 조회 API의 응답 속도를 향상시킵니다.
+          
+          ### 요청 파라미터
+          - `email` (String, required): 이메일
+          - `password` (String, required): 비밀번호
 
-            ### 응답 데이터
-            - 없음 (Void) (AccessToken은 `Authorization` 헤더, RefreshToken은 HttpOnly 쿠키에 설정)
+          ### 응답 데이터
+          - `accessToken` (String): 발급된 엑세스 토큰
+          - `refreshToken` (String): 발급된 리프레시 토큰
+          
+          ### 사용 방법
+          1. HTTP `POST /auth/login` 요청을 보냅니다.
+          2. 요청 본문에 LoginRequest JSON을 포함합니다.
+          3. 성공 시 응답 본문에 토큰 정보를 반환합니다.
 
-            ### 사용 방법
-            1. HTTP `POST /auth/login` 요청을 보냅니다.
-            2. 요청 본문에 LoginRequest JSON을 포함합니다.
-            3. 성공 시 `Authorization: Bearer {accessToken}` 헤더와 HttpOnly `refreshToken` 쿠키를 반환합니다.
+          ### 유의 사항
+          - **추천 계산 트리거:** 이 API는 성공적으로 로그인한 사용자의 추천 캐시가 없을 경우, 추천 목록 생성을 위한 백그라운드 작업을 트리거합니다. 
+          - 이후 추천 장학금 조회 API 호출 시, 이 계산이 진행 중이라면 `202 Accepted` 상태 코드가 반환될 수 있습니다.
 
-            ### 유의 사항
-            - HTTPS 환경에서만 사용해야 합니다.
-            - RefreshToken 쿠키는 `HttpOnly`, `SameSite=Strict`로 설정됩니다.
-
-            ### 예외 처리
-            - `INVALID_CREDENTIALS` (401): 아이디 또는 비밀번호가 올바르지 않습니다.
-            - `BAD_REQUEST` (400): 요청 형식 오류 시 반환됩니다.
-            - `INTERNAL_SERVER_ERROR` (500): 서버 내부 오류 발생 시 반환됩니다.
-            """
+          ### 예외 처리
+          - `INVALID_CREDENTIALS` (401): 아이디 또는 비밀번호가 올바르지 않습니다.
+          - `BAD_REQUEST` (400): 요청 형식 오류 시 반환됩니다.
+          - `INTERNAL_SERVER_ERROR` (500): 서버 내부 오류 발생 시 반환됩니다.
+          """
   )
   ResponseEntity<ApiResponse<Void>> login(
       LoginRequest request

--- a/src/main/java/com/grantip/backend/domain/user/service/AuthService.java
+++ b/src/main/java/com/grantip/backend/domain/user/service/AuthService.java
@@ -1,9 +1,9 @@
 package com.grantip.backend.domain.user.service;
 
 
-import com.grantip.backend.domain.email.repository.VerificationCodeRepository;
 import com.grantip.backend.domain.email.service.EmailService;
 import com.grantip.backend.domain.region.service.RegionService;
+import com.grantip.backend.domain.scholarship.service.RecommendationAsyncService;
 import com.grantip.backend.domain.scholarship.service.UniversityCategoryService;
 import com.grantip.backend.domain.token.domain.dto.TokenDto;
 import com.grantip.backend.domain.token.service.TokenService;
@@ -33,9 +33,9 @@ public class AuthService {
     private final JWTUtil jwtUtil;
     private final TokenService tokenService;
     private final EmailService emailService;
-    private final VerificationCodeRepository codeRepo;
     private final UniversityCategoryService universityCategoryService;
     private final RegionService regionService;
+    private final RecommendationAsyncService recommendationAsyncService;
 
     private static final String REDIS_PREFIX = "RT:";
 
@@ -84,6 +84,8 @@ public class AuthService {
 
             // 인증 성공 시 사용자 정보 가져오기
             CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            // 비동기 추천 계산 실행
+            recommendationAsyncService.triggerRecommendationCalculation(userDetails.getUsername());
 
             // 토큰 생성
             String accessToken = jwtUtil.createAccessToken(userDetails);

--- a/src/main/java/com/grantip/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/grantip/backend/global/config/RedisConfig.java
@@ -1,14 +1,20 @@
 package com.grantip.backend.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -47,12 +53,28 @@ public class RedisConfig {
         return new LettuceConnectionFactory(serverConfig, clientConfig);
     }
 
-    @Bean
-    public RedisTemplate<String, String> redisTemplate(LettuceConnectionFactory factory) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(factory);
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-        return template;
-    }
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(LettuceConnectionFactory factory, ObjectMapper objectMapper) {
+    RedisTemplate<String, Object> template = new RedisTemplate<>();
+    template.setConnectionFactory(factory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+    return template;
+  }
+
+  /**
+   * @Cacheable을 위한 CacheManager 설정
+   */
+  @Bean
+  public CacheManager cacheManager(LettuceConnectionFactory factory, ObjectMapper objectMapper) {
+    RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)))
+        .entryTtl(Duration.ofDays(1));
+
+    return RedisCacheManager.RedisCacheManagerBuilder
+        .fromConnectionFactory(factory)
+        .cacheDefaults(redisCacheConfiguration)
+        .build();
+  }
 }


### PR DESCRIPTION
## ✨ 변경 사항
- 장학금 추천 기능 비동기 폴링 아키텍처 도입
- 로그인 시 추천 계산 트리거 로직 추가
  - 사용자가 로그인에 성공했을 때, 해당 사용자의 추천 캐시가 존재하지 않으면 백그라운드에서 비동기적으로 추천 목록 계산을 시작하도록 수정 
  - 이 작업은 로그인 응답 시간에 영향을 주지 않음
- 추천 조회 API 상태 기반 응답 로직 구현
  - `GET /api/scholarships/recommendation` API가 추천 계산 상태에 따라 다른 HTTP 상태 코드를 반환하도록 수정
    - **`200 OK`**: 추천 데이터가 캐시에 존재하여 즉시 조회가 가능한 경우
    - **`202 Accepted`**: 현재 백그라운드에서 추천 데이터를 계산 중인 경우. 클라이언트는 이 응답을 받고 폴링을 시작해야 함
- Redis Lock을 이용한 동시성 제어
  - 동일 사용자에 대한 추천 계산 요청이 동시에 여러 번 발생해도, 실제 계산은 한 번만 실행되도록 Redis Lock을 통한 불필요한 리소스 낭비 방지
- Redis 캐시 설정 개선
  - `@Cacheable`이 Java 기본 직렬화가 아닌 JSON 형식으로 데이터를 저장하도록 `RedisCacheManager` Bean 설정

## 🔄 연관 이슈
- #28 

## ✅ 체크리스트
- [x] 코드 빌드/테스트 통과 (성능 측정 테스트 포함)
- [x] 문서·주석 업데이트 (Swagger API 문서 상세 업데이트 완료)

## 📖 기타
<!-- 필요한 추가 설명 -->
